### PR TITLE
Improve purchase feedback and add auto refresh

### DIFF
--- a/src/features/kittiesList/useRefreshKittiesList.ts
+++ b/src/features/kittiesList/useRefreshKittiesList.ts
@@ -1,0 +1,30 @@
+import { useEffect } from "react";
+import { getKitties } from ".";
+import { useAppDispatch } from "../../app/hooks";
+
+type UseRefreshKittiesListProps = {
+  intervalMilliseconds?: number;
+  accountKey?: string;
+};
+
+/**
+ * Custom hook to refresh the kitties list at a given interval.
+ * 
+ * If no interval is provided, the kitties list will only refresh once.
+ * Specify an account key to get the kitties owned by that account.
+ */
+export const useRefreshKittiesList = ({ intervalMilliseconds, accountKey }: UseRefreshKittiesListProps = {}) => {
+  const dispatch = useAppDispatch();
+  
+  useEffect(() => {
+    dispatch(getKitties(accountKey));
+
+    if (!intervalMilliseconds || intervalMilliseconds <= 0) return;
+    
+    const interval = setInterval(() => {
+      dispatch(getKitties(accountKey));
+    }, intervalMilliseconds);
+
+    return () => clearInterval(interval);
+  }, [dispatch, intervalMilliseconds, accountKey]);
+}

--- a/src/features/wallet/index.tsx
+++ b/src/features/wallet/index.tsx
@@ -90,7 +90,7 @@ export const WalletSelector = () => {
       connectWallet().catch((error) => {
         toast({
           title: "Error connecting wallet",
-          description: error,
+          description: error.message,
           status: "error",
           duration: 9000,
           isClosable: true,

--- a/src/pages/MyKitties.tsx
+++ b/src/pages/MyKitties.tsx
@@ -113,7 +113,7 @@ export const MyKitties = () => {
                   </Tr>
                 </Thead>
                 <Tbody>
-                {filteredList.map(({ item }) => (
+                  {filteredList.map(({ item }) => (
                     <Tr
                       key={item?.dna}
                       onClick={handleRowClick("/details", item)}

--- a/src/pages/MyKitties.tsx
+++ b/src/pages/MyKitties.tsx
@@ -25,13 +25,14 @@ import {
 import { Link, To, useNavigate } from "react-router-dom";
 import { EggIcon, SearchIcon } from "chakra-ui-ionicons";
 import { useAppDispatch, useAppSelector } from "../app/hooks";
-import { getKitties, selectError, selectKitties, selectStatus } from "../features/kittiesList";
+import { selectError, selectKitties, selectStatus } from "../features/kittiesList";
 import { selectAccount } from "../features/wallet/walletSlice";
 import { setKitty } from "../features/kittyDetails";
 import { Kitty } from "../types";
 import Fuse, { FuseResult } from "fuse.js";
 import { LoadingStatus } from "../components/LoadingStatus";
 import { getStatusColor } from "../utils";
+import { useRefreshKittiesList } from "../features/kittiesList/useRefreshKittiesList";
 
 export const MyKitties = () => {
   const navigate = useNavigate();
@@ -47,10 +48,8 @@ export const MyKitties = () => {
   });
   const message = error ?? filteredList.length === 0 ? "No kitties found" : undefined;
 
-  useEffect(() => {
-    if (!account) return;
-    dispatch(getKitties(account.key));
-  }, [account]);
+  useRefreshKittiesList({ intervalMilliseconds: 10000, accountKey: account?.key });
+
   const handleRowClick = (page: To, kitty: Kitty) => () => {
     dispatch(setKitty(kitty));
     navigate(page);
@@ -114,7 +113,7 @@ export const MyKitties = () => {
                   </Tr>
                 </Thead>
                 <Tbody>
-                  {filteredList.map(({ item }) => (
+                {filteredList.map(({ item }) => (
                     <Tr
                       key={item?.dna}
                       onClick={handleRowClick("/details", item)}

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -24,7 +24,6 @@ import { SearchIcon } from "chakra-ui-ionicons";
 import Fuse, { FuseResult } from "fuse.js";
 import { useAppDispatch, useAppSelector } from "../app/hooks";
 import {
-  getKitties,
   selectError,
   selectKitties,
   selectStatus,
@@ -33,6 +32,7 @@ import { Kitty } from "../types";
 import { setKitty } from "../features/kittyDetails";
 import { LoadingStatus } from "../components/LoadingStatus";
 import { getStatusColor } from "../utils";
+import { useRefreshKittiesList } from "../features/kittiesList/useRefreshKittiesList";
 
 const fuseOptions = {
   // isCaseSensitive: false,
@@ -59,15 +59,15 @@ export const Search = () => {
   const error = useAppSelector(selectError);
   const fuse = new Fuse(list, fuseOptions);
 
+  useRefreshKittiesList({ intervalMilliseconds: 10000 });
+
   const message = error ?? filteredList.length === 0 ? "No kitties found" : undefined;
 
   const handleRowClick = (page: To, kitty: Kitty) => () => {
     dispatch(setKitty(kitty));
     navigate(page);
   };
-  useEffect(() => {
-    dispatch(getKitties());
-  }, [dispatch]);
+
   useEffect(() => {
     setList(list.map((kitty) => ({ item: kitty, refIndex: 1 })));
   }, [list]);


### PR DESCRIPTION
This fixes #58 by providing feedback to the user after purchasing a kitty and auto refreshing the kitties list. 

## Changes
- Improve toast message on purchase so that it shows only after the transaction has been submitted and includes a message about the kitty details updating after tx confirmation
- Add auto refresh behavior to all pages (fetch latest kitties data from backend every 10 seconds)

There is still the possibility that the user disregards the message about the details updating only after transaction confirmation, and they proceed to very quickly purchase the same kitty within 10 seconds. This would trigger the error outlined in #58, but I believe this would be an edge case / user error.

After 10 seconds, the tx should be confirmed, the UI will auto update, and the user would no longer see any option to buy the kitty that they now own.